### PR TITLE
Bug: incorrect php version for symfony/css-selector as of 2020/01/01

### DIFF
--- a/LibMetrics.Test/Integration/PackagistRepositoryTest.cs
+++ b/LibMetrics.Test/Integration/PackagistRepositoryTest.cs
@@ -29,5 +29,18 @@ namespace LibMetrics.Test.Integration
 
       Assert.Equal("2.0.2", versionInfo.Version);
     }
+
+    [Fact]
+    public void LatestAsOfForSymfonyCssSelector() {
+      var phpFixturePath = Fixtures.Path("php", "small");
+      var fileFinder = new FileHistoryFinder(phpFixturePath);
+      var repository = new MulticastComposerRepository(phpFixturePath, fileFinder.Finder);
+
+      var versionInfo = repository.LatestAsOf(
+        new DateTime(2020, 01, 01),
+        "symfony/css-selector");
+
+      Assert.Equal("v5.0.2", versionInfo.Version);
+    }
   }
 }

--- a/LibMetrics/FileSystemInfoExtensions.cs
+++ b/LibMetrics/FileSystemInfoExtensions.cs
@@ -10,7 +10,6 @@ namespace LibMetrics
     // modifications: does not descend into symbolic link directories
     public static void DeleteReadOnly(this FileSystemInfo fileSystemInfo)
     {
-      System.Console.WriteLine(fileSystemInfo.FullName);
       if (!fileSystemInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
       {
         var directoryInfo = fileSystemInfo as DirectoryInfo;

--- a/LibMetrics/Languages/Php/ComposerRepository.cs
+++ b/LibMetrics/Languages/Php/ComposerRepository.cs
@@ -50,7 +50,10 @@ namespace LibMetrics.Languages.Php
         foundVersions.Add((version, publishedDate.Date));
       }
 
-      foundVersions.Sort((left, right) => left.PublishedAt.CompareTo(right.PublishedAt));
+      foundVersions.Sort((left, right) =>
+        left.Version.CompareTo(right.Version) |
+          left.PublishedAt.CompareTo(right.PublishedAt)
+      );
       var filteredVersions = foundVersions.Where(item => item.PublishedAt <= date).ToArray();
       if (!filteredVersions.Any()) return null;
       var selectedItem = filteredVersions.Last();


### PR DESCRIPTION
`symfony/css-selector` version `v3.4.37` was released on 2020/01/01. But version `v5.0.2` was released on 2019/11/18. The `LatestAsOf` method is incorrectly assuming that the most recently published package is the latest one. It instead should be returning the highest version number that was published as of the specified date. That would be `v5.0.2` in this case.

This pull request has been seeded with a failing test case. A good first issue for anyone looking to contribute. :)